### PR TITLE
DEVOPS-473: Add moved-to-monorepo notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+> ⚠️ **Moved to the monorepo.**
+> This module now lives in [`opstimus/terraform-modules`](https://github.com/opstimus/terraform-modules) at `modules/mongodb-advance`.
+>
+> ```hcl
+> source = "git::https://github.com/opstimus/terraform-modules.git//modules/mongodb-advance?ref=mongodb-advance/v1.0.0"
+> ```
+>
+> This repository remains for existing consumers; new development happens in the monorepo.
+
 # MongoDB Cluster Module
 
 ## Description


### PR DESCRIPTION
This module has been migrated to [opstimus/terraform-modules](https://github.com/opstimus/terraform-modules) (`modules/mongodb-advance`). This PR prepends a notice to the README pointing existing consumers to the new source location. This repo remains live; no other changes.